### PR TITLE
Add another EC2 instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,3 +27,7 @@ module "compute" {
   common_tags          = local.common_tags
 }
 
+output "another_instance_public_ip" {
+  description = "Public IP of the another EC2 instance"
+  value       = module.compute.another_instance_public_ip
+}

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -47,4 +47,24 @@ resource "aws_instance" "web" {
               EOF
 
   tags = merge(var.common_tags, { Name = "${var.project}-web" })
-} 
+}
+
+resource "aws_instance" "another-instance" {
+  ami           = data.aws_ami.amazon_linux_2.id
+  instance_type = var.instance_type
+  
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [aws_security_group.ec2.id]
+  associate_public_ip_address = true
+
+  user_data = <<-EOF
+              #!/bin/bash
+              yum update -y
+              yum install -y httpd
+              systemctl start httpd
+              systemctl enable httpd
+              echo "<h1>Hello from another instance of ${var.project}!</h1>" > /var/www/html/index.html
+              EOF
+
+  tags = merge(var.common_tags, { Name = "${var.project}-another-instance" })
+}

--- a/modules/compute/outputs.tf
+++ b/modules/compute/outputs.tf
@@ -11,4 +11,14 @@ output "instance_public_ip" {
 output "security_group_id" {
   description = "ID of the EC2 security group"
   value       = aws_security_group.ec2.id
-} 
+}
+
+output "another_instance_id" {
+  description = "ID of the another EC2 instance"
+  value       = aws_instance.another_instance.id
+}
+
+output "another_instance_public_ip" {
+  description = "Public IP of the another EC2 instance"
+  value       = aws_instance.another_instance.public_ip
+}

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -68,4 +68,10 @@ resource "aws_lb_target_group_attachment" "web" {
   target_group_arn = aws_lb_target_group.web.arn
   target_id        = var.instance_id
   port             = 80
-} 
+}
+
+resource "aws_lb_target_group_attachment" "another_instance" {
+  target_group_arn = aws_lb_target_group.web.arn
+  target_id        = var.another_instance_id
+  port             = 80
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,4 +11,9 @@ output "instance_public_ip" {
 output "vpc_id" {
   description = "ID of the VPC"
   value       = module.networking.vpc_id
-} 
+}
+
+output "another_instance_public_ip" {
+  description = "Public IP of the another EC2 instance"
+  value       = module.compute.another_instance_public_ip
+}


### PR DESCRIPTION
Add a new EC2 instance called "another-instance" and update related configurations.

* **modules/compute/main.tf**
  - Add a new `aws_instance` resource named "another-instance" with similar configuration to the existing "web" instance.

* **modules/compute/outputs.tf**
  - Add an output for the new instance's ID.
  - Add an output for the new instance's public IP.

* **main.tf**
  - Add an output for the new instance's public IP.

* **modules/loadbalancer/main.tf**
  - Add a new `aws_lb_target_group_attachment` resource to reference the new instance.

* **outputs.tf**
  - Add an output for the new instance's public IP.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomronen/env0-demo?shareId=XXXX-XXXX-XXXX-XXXX).